### PR TITLE
FIX: set `__module__` on `DerivedException` 🐛

### DIFF
--- a/combadge/core/response.py
+++ b/combadge/core/response.py
@@ -163,6 +163,7 @@ class ErrorResponse(BaseResponse, ABC):
                 - This docstring is overridden by the corresponding model docstring.
             """
 
+        DerivedException.__module__ = cls.__module__
         DerivedException.__name__ = f"{cls.__name__}.Error"
         DerivedException.__qualname__ = f"{cls.__qualname__}.Error"
         DerivedException.__doc__ = cls.__doc__ or DerivedException.__doc__

--- a/tests/core/test_response.py
+++ b/tests/core/test_response.py
@@ -44,3 +44,12 @@ def test_custom_raise_for_result() -> None:
 
     assert isinstance(e.value.__cause__, Error.Error)
     assert e.value.__cause__.response is response
+
+
+def test_derived_error_magic_attributes() -> None:
+    class CustomError(ErrorResponse):
+        pass
+
+    assert CustomError.Error.__module__ == "tests.core.test_response"
+    assert CustomError.Error.__name__ == "CustomError.Error"
+    assert CustomError.Error.__qualname__ == "test_derived_error_magic_attributes.<locals>.CustomError.Error"


### PR DESCRIPTION
Otherwise, `DerivedException.__module__` is `combadge.core.response`, leading to incorrect `str()` and `repr()` output for user error models.