### PR TITLE
OPT: Support list query parameters

### DIFF
--- a/combadge/support/http/markers/request.py
+++ b/combadge/support/http/markers/request.py
@@ -117,6 +117,11 @@ class QueryParam(ParameterMarker[ContainsQueryParams]):
 
     @override
     def __call__(self, request: ContainsQueryParams, value: Any) -> None:  # noqa: D102
+        if isinstance(value, list):
+            for sub_value in value:
+                request.query_params.append((self.name, sub_value.value if isinstance(sub_value, Enum) else sub_value))
+            return
+
         request.query_params.append((self.name, value.value if isinstance(value, Enum) else value))
 
 

--- a/tests/integration/cassettes/test_httpbin/test_query_params.yaml
+++ b/tests/integration/cassettes/test_httpbin/test_query_params.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: ''
     headers:
       accept:
       - '*/*'
@@ -8,25 +8,21 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      content-length:
-      - '2'
-      content-type:
-      - application/json
       host:
       - httpbin.org
       user-agent:
-      - python-httpx/0.23.3
+      - python-httpx/0.25.2
     method: GET
-    uri: https://httpbin.org/anything?foobar=100500&foobar=100501
+    uri: https://httpbin.org/anything?foobar=100500&foobar=100501&multivalue=value1&multivalue=value2
   response:
     content: "{\n  \"args\": {\n    \"foobar\": [\n      \"100500\", \n      \"100501\"\n
-      \   ]\n  }, \n  \"data\": \"{}\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\":
+      \   ], \n    \"multivalue\": [\n      \"value1\", \n      \"value2\"\n    ]\n
+      \ }, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\":
       {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\": \"gzip, deflate\", \n
-      \   \"Content-Length\": \"2\", \n    \"Content-Type\": \"application/json\",
-      \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"python-httpx/0.23.3\",
-      \n    \"X-Amzn-Trace-Id\": \"Root=1-6408b26f-2f167e16119c85211f5273ad\"\n  },
-      \n  \"json\": {}, \n  \"method\": \"GET\", \n  \"origin\": \"86.94.162.190\",
-      \n  \"url\": \"https://httpbin.org/anything?foobar=100500&foobar=100501\"\n}\n"
+      \   \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"python-httpx/0.25.2\",
+      \n    \"X-Amzn-Trace-Id\": \"Root=1-67110318-43fea4d527e15c1c6985b29d\"\n  },
+      \n  \"json\": null, \n  \"method\": \"GET\", \n  \"origin\": \"199.103.8.49\",
+      \n  \"url\": \"https://httpbin.org/anything?foobar=100500&foobar=100501&multivalue=value1&multivalue=value2\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -35,11 +31,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '546'
+      - '572'
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:06:08 GMT
+      - Thu, 17 Oct 2024 12:29:12 GMT
       Server:
       - gunicorn/19.9.0
     http_version: HTTP/1.1

--- a/tests/integration/test_httpbin.py
+++ b/tests/integration/test_httpbin.py
@@ -52,12 +52,13 @@ def test_query_params() -> None:
             self,
             foo: Annotated[int, QueryParam("foobar")],
             bar: Annotated[int, QueryParam("foobar")],
+            multivalue: Annotated[list[str], QueryParam("multivalue")],
         ) -> Response: ...
 
     service = SupportsHttpbin.bind(SyncHttpxBackend(Client(base_url="https://httpbin.org")))
-    response = service.get_anything(foo=100500, bar=100501)
+    response = service.get_anything(foo=100500, bar=100501, multivalue=["value1","value2"])
 
-    assert response == Response(args={"foobar": ["100500", "100501"]})
+    assert response == Response(args={"foobar": ["100500", "100501"], "multivalue": ["value1", "value2"]})
 
 
 class _HeadersResponse(BaseModel):


### PR DESCRIPTION
Before this change it would URL encode the python representation of the list.
With this change it will pass the query parameter as `?multivalue=value1&multivalue=value2`

I was doubting whether to use `isinstance(.., list)` vs something more generic like `isinstance(.., Collection)`, but i believe list is the most appropriate typing. It has order, and it clearly defines what would be expected when passing a list as a query parameter.