### PR TITLE
NEW: `QueryArrayParam` marker for HTTP GET parameters ✨

### DIFF
--- a/combadge/support/http/markers/request.py
+++ b/combadge/support/http/markers/request.py
@@ -117,12 +117,30 @@ class QueryParam(ParameterMarker[ContainsQueryParams]):
 
     @override
     def __call__(self, request: ContainsQueryParams, value: Any) -> None:  # noqa: D102
-        if isinstance(value, list):
-            for sub_value in value:
-                request.query_params.append((self.name, sub_value.value if isinstance(sub_value, Enum) else sub_value))
-            return
-
         request.query_params.append((self.name, value.value if isinstance(value, Enum) else value))
+
+
+@dataclass(**SLOTS)
+class QueryArrayParam(ParameterMarker[ContainsQueryParams]):
+    """
+    Mark parameter as an array-like query parameter.
+
+    Supports any iterable value as a call argument.
+
+    Examples:
+        >>> def call(query: Annotated[list[str], QueryParam("query")]) -> ...:
+        >>>     ...
+
+        >>> def call(query: Annotated[Iterable[str], QueryParam("query")]) -> ...:
+        >>>     ...
+    """
+
+    name: str
+
+    @override
+    def __call__(self, request: ContainsQueryParams, value: Any) -> None:  # noqa: D102
+        for sub_value in value:
+            request.query_params.append((self.name, sub_value.value if isinstance(sub_value, Enum) else sub_value))
 
 
 if not TYPE_CHECKING:

--- a/tests/integration/test_httpbin.py
+++ b/tests/integration/test_httpbin.py
@@ -8,7 +8,16 @@ from pydantic import BaseModel
 from combadge.core.errors import BackendError
 from combadge.core.interfaces import SupportsService
 from combadge.core.markers import Mixin
-from combadge.support.http.markers import CustomHeader, FormData, FormField, Header, QueryParam, http_method, path
+from combadge.support.http.markers import (
+    CustomHeader,
+    FormData,
+    FormField,
+    Header,
+    QueryArrayParam,
+    QueryParam,
+    http_method,
+    path,
+)
 from combadge.support.httpx.backends.async_ import HttpxBackend as AsyncHttpxBackend
 from combadge.support.httpx.backends.sync import HttpxBackend as SyncHttpxBackend
 
@@ -51,11 +60,11 @@ def test_query_params() -> None:
             self,
             foo: Annotated[int, QueryParam("foobar")],
             bar: Annotated[int, QueryParam("foobar")],
-            multivalue: Annotated[list[str], QueryParam("multivalue")],
+            multivalue: Annotated[list[str], QueryArrayParam("multivalue")],
         ) -> Response: ...
 
     service = SupportsHttpbin.bind(SyncHttpxBackend(Client(base_url="https://httpbin.org")))
-    response = service.get_anything(foo=100500, bar=100501, multivalue=["value1","value2"])
+    response = service.get_anything(foo=100500, bar=100501, multivalue=["value1", "value2"])
 
     assert response == Response(args={"foobar": ["100500", "100501"], "multivalue": ["value1", "value2"]})
 


### PR DESCRIPTION
Related: #133 