### PR TITLE
BREAK: remove shortcuts `Payload[...]`, `Header[...]`, and `FormData[…]` 💥

### DIFF
--- a/.idea/combadge.iml
+++ b/.idea/combadge.iml
@@ -2,8 +2,8 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/combadge" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/.mypy_cache" />
       <excludeFolder url="file://$MODULE_DIR$/.pytest_cache" />
@@ -12,7 +12,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.cache" />
       <excludeFolder url="file://$MODULE_DIR$/_site" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.13 virtualenv at ~/GitHub/combadge/.venv" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.13 (combadge)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="Black">
     <option name="sdkName" value="Poetry (combadge)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 virtualenv at ~/GitHub/combadge/.venv" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (combadge)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />
   </component>

--- a/combadge/support/soap/markers.py
+++ b/combadge/support/soap/markers.py
@@ -1,8 +1,9 @@
+from collections.abc import Hashable
 from dataclasses import dataclass
 from inspect import BoundArguments
-from typing import TYPE_CHECKING, Annotated, Any, Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar, cast
 
-from typing_extensions import TypeAlias, override
+from typing_extensions import override
 
 from combadge._helpers.dataclasses import SLOTS
 from combadge._helpers.pydantic import get_type_adapter
@@ -39,46 +40,34 @@ def operation_name(name: str) -> Callable[[FunctionT], FunctionT]:
     return OperationName[Any](name).mark
 
 
-if not TYPE_CHECKING:
+@dataclass(**SLOTS)
+class Header(ParameterMarker[ContainsSoapHeader]):
+    """
+    Mark parameter as a request header.
 
-    @dataclass(**SLOTS)
-    class Header(ParameterMarker[ContainsSoapHeader]):
-        """
-        Mark parameter as a request header.
+    An argument gets converted to a dictionary and passed over to a backend.
 
-        An argument gets converted to a dictionary and passed over to a backend.
+    Examples:
+        >>> def call(body: Annotated[HeaderModel, Header()]) -> ...:
+        >>>     ...
+    """
 
-        Examples:
-            Simple usage:
+    exclude_unset: bool = False
+    by_alias: bool = False
 
-            >>> def call(body: Header[HeaderModel]) -> ...:
-            >>>     ...
+    @override
+    def __call__(self, request: ContainsSoapHeader, value: Any) -> None:  # noqa: D102
+        value = get_type_adapter(cast(Hashable, type(value))).dump_python(
+            value,
+            by_alias=self.by_alias,
+            exclude_unset=self.exclude_unset,
+        )
+        if request.soap_header is None:
+            request.soap_header = value
+        elif isinstance(request.soap_header, dict):
+            request.soap_header.update(value)  # merge into the existing header
+        else:
+            raise ValueError(f"attempting to merge `{type(value)}` into `{type(request.soap_header)}`")
 
-            Equivalent expanded usage:
-
-            >>> def call(body: Annotated[HeaderModel, Header()]) -> ...:
-            >>>     ...
-        """
-
-        exclude_unset: bool = False
-        by_alias: bool = False
-
-        @override
-        def __call__(self, request: ContainsSoapHeader, value: Any) -> None:  # noqa: D102
-            value = get_type_adapter(type(value)).dump_python(
-                value,
-                by_alias=self.by_alias,
-                exclude_unset=self.exclude_unset,
-            )
-            if request.soap_header is None:
-                request.soap_header = value
-            elif isinstance(request.soap_header, dict):
-                request.soap_header.update(value)  # merge into the existing header
-            else:
-                raise ValueError(f"attempting to merge `{type(value)}` into `{type(request.soap_header)}`")
-
-        def __class_getitem__(cls, item: type[Any]) -> Any:
-            return Annotated[item, cls()]
-
-else:
-    FormData: TypeAlias = _T
+    def __class_getitem__(cls, item: type[Any]) -> Any:
+        raise NotImplementedError("the shortcut is no longer supported, use `Annotated[..., Header()]`")

--- a/docs/support/models/index.md
+++ b/docs/support/models/index.md
@@ -18,7 +18,7 @@ from httpx import Client
 class Httpbin(Protocol):
     @http_method("POST")
     @path("/anything")
-    def post_anything(self, foo: Payload[int]) -> Annotated[int, Extract("data")]:
+    def post_anything(self, foo: Annotated[int, Payload()]) -> Annotated[int, Extract("data")]:
         ...
 
 
@@ -31,7 +31,7 @@ assert backend[Httpbin].post_anything(42) == 42
 ```python title="dataclasses.py" hl_lines="10-12 15-17 23 28"
 from dataclasses import dataclass
 
-from typing_extensions import Protocol
+from typing_extensions import Protocol, Annotated
 
 from combadge.support.httpx.backends.sync import HttpxBackend
 from combadge.support.http.markers import Payload, http_method, path
@@ -51,7 +51,7 @@ class Response:
 class Httpbin(Protocol):
     @http_method("POST")
     @path("/anything")
-    def post_anything(self, foo: Payload[Request]) -> Response:
+    def post_anything(self, foo: Annotated[Request, Payload()]) -> Response:
         ...
 
 
@@ -62,7 +62,7 @@ assert backend[Httpbin].post_anything(Request(42)) == Response(data='{"foo": 42}
 ## [Typed dictionaries](https://docs.python.org/3/library/typing.html#typing.TypedDict)
 
 ```python title="typed_dict.py" hl_lines="8-9 12-13 19 24"
-from typing_extensions import Protocol, TypedDict
+from typing_extensions import Protocol, TypedDict, Annotated
 
 from combadge.support.httpx.backends.sync import HttpxBackend
 from combadge.support.http.markers import Payload, http_method, path
@@ -80,7 +80,7 @@ class Response(TypedDict):
 class Httpbin(Protocol):
     @http_method("POST")
     @path("/anything")
-    def post_anything(self, foo: Payload[Request]) -> Response:
+    def post_anything(self, foo: Annotated[Request, Payload()]) -> Response:
         ...
 
 

--- a/tests/core/markers/test_parameter.py
+++ b/tests/core/markers/test_parameter.py
@@ -3,14 +3,13 @@ from typing import Annotated, Any
 import pytest
 
 from combadge.core.markers.parameter import ParameterMarker
-from combadge.support.http.markers import CustomHeader, Payload
+from combadge.support.http.markers import CustomHeader
 
 
 @pytest.mark.parametrize(
     ("type_", "expected"),
     [
         (int, []),
-        (Payload[int], [Payload()]),
         (Annotated[str, CustomHeader("X-Header")], [CustomHeader("X-Header")]),
     ],
 )

--- a/tests/integration/test_httpbin.py
+++ b/tests/integration/test_httpbin.py
@@ -36,7 +36,7 @@ def test_form_data() -> None:
         @abstractmethod
         def post_anything(
             self,
-            data: FormData[Data],
+            data: Annotated[Data, FormData()],
             bar: Annotated[int, FormField("barqux")],
             qux: Annotated[int, FormField("barqux")],
         ) -> Response: ...


### PR DESCRIPTION
MyPy is having a hard time properly supporting generic classes with overridden `__class_getitem__()`, so having these shortcuts creates more problems than it solves. I'm removing the overrides for the time being, until MyPy implements a proper support for them.