### PR TITLE
BREAK: simplify the backend and binding interfaces 💥

### DIFF
--- a/combadge/core/binder.py
+++ b/combadge/core/binder.py
@@ -15,7 +15,8 @@ from combadge.core.service import BaseBoundService
 from combadge.core.typevars import BackendT, FunctionT, ServiceProtocolT
 
 if TYPE_CHECKING:
-    from combadge.core.interfaces import MethodBinder, ProvidesBinder, ServiceMethod
+    from combadge.core.backend import BaseBackend
+    from combadge.core.interfaces import ServiceMethod
 
     def lru_cache(maxsize: int | None) -> Callable[[FunctionT], FunctionT]: ...
 
@@ -23,7 +24,7 @@ else:
     from functools import lru_cache
 
 
-def bind(from_protocol: type[ServiceProtocolT], to_backend: ProvidesBinder) -> ServiceProtocolT:
+def bind(from_protocol: type[ServiceProtocolT], to_backend: BaseBackend) -> ServiceProtocolT:
     """
     Create a service instance which implements the specified protocol by calling the specified backend.
 
@@ -32,13 +33,13 @@ def bind(from_protocol: type[ServiceProtocolT], to_backend: ProvidesBinder) -> S
         to_backend: backend which should perform the service requests
     """
 
-    return bind_class(from_protocol, to_backend.binder)(to_backend)
+    return bind_class(from_protocol, to_backend)(to_backend)
 
 
 @lru_cache(maxsize=100)
 def bind_class(
     from_protocol: type[ServiceProtocolT],
-    bind_method: MethodBinder[BackendT],
+    to_backend: BackendT,
 ) -> Callable[[BackendT], ServiceProtocolT]:
     """Create a class which implements the specified protocol, but not yet parametrized with a backend."""
 
@@ -51,7 +52,7 @@ def bind_class(
 
     for name, method in _enumerate_methods(from_protocol):
         signature = Signature.from_method(method)
-        bound_method: ServiceMethod = bind_method(signature)  # generate implementation by the backend
+        bound_method: ServiceMethod = to_backend.bind_method(signature)  # generate implementation by the backend
         update_wrapper(bound_method, method)
         bound_method = _wrap(bound_method, signature.method_markers)
         bound_method = override(bound_method)  # no functional change, just possibly setting `__override__`

--- a/combadge/core/interfaces.py
+++ b/combadge/core/interfaces.py
@@ -1,81 +1,12 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from types import TracebackType
 from typing import Any, Protocol
 
 from pydantic import BaseModel
-from typing_extensions import Self
 
-from combadge.core.binder import BaseBoundService, bind
-from combadge.core.signature import Signature
+from combadge.core.binder import BaseBoundService
 from combadge.core.typevars import BackendT
-
-
-class SupportsService(Protocol):
-    """
-    Convenience base for service protocols.
-
-    Tip:
-        Combadge can inspect any `Protocol` or `ABC`.
-        But it might be a little easier to inherit from `#!python SupportsService`
-        since it provides the `bind(to_backend)` method as a shorthand for `#!python bind(from_protocol, to_backend)`.
-    """
-
-    @classmethod
-    def bind(cls, to_backend: ProvidesBinder, /) -> Self:
-        """Bind the current protocol to the specified backend."""
-        return bind(cls, to_backend)
-
-    def __enter__(self) -> Self:
-        return self
-
-    async def __aenter__(self) -> Self:
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> Any:
-        return None
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> Any:
-        return None
-
-
-class MethodBinder(Protocol[BackendT]):  # noqa: D101
-    @staticmethod
-    @abstractmethod
-    def __call__(signature: Signature, /) -> ServiceMethod[BackendT]:
-        """
-        Bind the method by its signature (for example, a backend).
-
-        Args:
-            signature: extracted method signature
-
-        Returns:
-            Callable service method which is then fully capable of sending a request and receiving a response
-            via a corresponding backend instance.
-        """
-        raise NotImplementedError
-
-
-class ProvidesBinder(Protocol):
-    """
-    Provides a default binder for itself.
-
-    This is a convenience protocol that allows implementing a shortcut `bind` method instead of
-    forcing a user to bind the class manually.
-    """
-
-    binder: MethodBinder[Self]
 
 
 class ServiceMethod(Protocol[BackendT]):

--- a/combadge/core/typevars.py
+++ b/combadge/core/typevars.py
@@ -1,8 +1,11 @@
 """Internal type variables."""
 
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
-BackendT = TypeVar("BackendT")
+if TYPE_CHECKING:
+    from combadge.core.backend import BaseBackend
+
+BackendT = TypeVar("BackendT", bound="BaseBackend")
 """Backend type."""
 
 BackendRequestT = TypeVar("BackendRequestT")

--- a/combadge/support/httpx/backends/base.py
+++ b/combadge/support/httpx/backends/base.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
+from abc import ABC
 from typing import Any, Generic, TypeVar
 
 from httpx import AsyncClient, Client, Response
 
-from combadge.core.interfaces import ProvidesBinder
+from combadge.core.backend import BaseBackend
 
 _ClientT = TypeVar("_ClientT", Client, AsyncClient)
 
 
-class BaseHttpxBackend(ProvidesBinder, Generic[_ClientT]):
+class BaseHttpxBackend(BaseBackend, Generic[_ClientT], ABC):
     """[HTTPX](https://www.python-httpx.org/) client support."""
 
-    _client: _ClientT
+    __slots__ = ("_service_cache", "_client", "_raise_for_status")
 
     def __init__(self, client: _ClientT, *, raise_for_status: bool = True) -> None:  # noqa: D107
-        self._client = client
+        super().__init__()
+        self._client: _ClientT = client
         self._raise_for_status = raise_for_status
 
     def _parse_payload(self, from_response: Response) -> Any:

--- a/combadge/support/httpx/backends/sync.py
+++ b/combadge/support/httpx/backends/sync.py
@@ -6,10 +6,9 @@ from typing import Any, cast
 
 from httpx import Client, Response
 from pydantic import TypeAdapter
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from combadge._helpers.pydantic import get_type_adapter
-from combadge.core.backend import ServiceContainer
 from combadge.core.binder import BaseBoundService
 from combadge.core.errors import BackendError
 from combadge.core.interfaces import ServiceMethod
@@ -18,10 +17,10 @@ from combadge.support.http.request import Request
 from combadge.support.httpx.backends.base import BaseHttpxBackend
 
 
-class HttpxBackend(BaseHttpxBackend[Client], ServiceContainer):
+class HttpxBackend(BaseHttpxBackend[Client]):
     """Sync HTTPX backend."""
 
-    __slots__ = ("_client", "_service_cache", "_raise_for_status")
+    __slots__ = ("_service_cache", "_client", "_raise_for_status")
 
     def __init__(
         self,
@@ -37,9 +36,10 @@ class HttpxBackend(BaseHttpxBackend[Client], ServiceContainer):
             raise_for_status: automatically call `raise_for_status()`
         """
         BaseHttpxBackend.__init__(self, client, raise_for_status=raise_for_status)
-        ServiceContainer.__init__(self)
 
-    def bind_method(self, signature: Signature) -> ServiceMethod[HttpxBackend]:  # noqa: D102
+    @classmethod
+    @override
+    def bind_method(cls, signature: Signature) -> ServiceMethod[HttpxBackend]:  # noqa: D102
         response_type: TypeAdapter[Any] = get_type_adapter(cast(Hashable, signature.return_type))
 
         def bound_method(self: BaseBoundService[HttpxBackend], *args: Any, **kwargs: Any) -> Any:
@@ -57,8 +57,6 @@ class HttpxBackend(BaseHttpxBackend[Client], ServiceContainer):
             return signature.apply_response_markers(response, payload, response_type)
 
         return bound_method  # type: ignore[return-value]
-
-    binder = bind_method  # type: ignore[assignment]
 
     def __enter__(self) -> Self:
         self._client = self._client.__enter__()

--- a/combadge/support/zeep/backends/async_.py
+++ b/combadge/support/zeep/backends/async_.py
@@ -7,7 +7,7 @@ from types import TracebackType
 from typing import Any
 
 import httpx
-from typing_extensions import Self
+from typing_extensions import Self, override
 from zeep import AsyncClient, Plugin
 from zeep.exceptions import Fault
 from zeep.helpers import serialize_object
@@ -15,7 +15,6 @@ from zeep.proxy import AsyncOperationProxy, AsyncServiceProxy
 from zeep.transports import AsyncTransport
 from zeep.wsse import UsernameToken
 
-from combadge.core.backend import ServiceContainer
 from combadge.core.binder import BaseBoundService
 from combadge.core.errors import BackendError
 from combadge.core.interfaces import ServiceMethod
@@ -24,10 +23,7 @@ from combadge.support.soap.request import Request
 from combadge.support.zeep.backends.base import BaseZeepBackend, ByBindingName, ByServiceName
 
 
-class ZeepBackend(
-    BaseZeepBackend[AsyncServiceProxy, AsyncOperationProxy],
-    ServiceContainer,
-):
+class ZeepBackend(BaseZeepBackend[AsyncServiceProxy, AsyncOperationProxy]):
     """Asynchronous Zeep service."""
 
     __slots__ = ("_service", "_service_cache")
@@ -95,10 +91,11 @@ class ZeepBackend(
             service: [service proxy object](https://docs.python-zeep.org/en/master/client.html#the-serviceproxy-object)
         """
         BaseZeepBackend.__init__(self, service)
-        ServiceContainer.__init__(self)
 
-    def bind_method(self, signature: Signature) -> ServiceMethod[ZeepBackend]:  # noqa: D102
-        response_type, fault_type = self._adapt_response_type(signature.return_type)
+    @classmethod
+    @override
+    def bind_method(cls, signature: Signature, /) -> ServiceMethod[ZeepBackend]:  # noqa: D102
+        response_type, fault_type = cls._adapt_response_type(signature.return_type)
 
         async def bound_method(self: BaseBoundService[ZeepBackend], *args: Any, **kwargs: Any) -> Any:
             request = signature.build_request(Request, self, args, kwargs)

--- a/combadge/support/zeep/backends/base.py
+++ b/combadge/support/zeep/backends/base.py
@@ -8,6 +8,7 @@ from annotated_types import SLOTS
 from pydantic_core import Url
 
 from combadge._helpers.pydantic import get_type_adapter
+from combadge.core.backend import BaseBackend
 from combadge.core.errors import BackendError
 
 try:
@@ -22,7 +23,6 @@ from typing_extensions import get_origin as get_type_origin
 from zeep.exceptions import Fault
 from zeep.proxy import OperationProxy, ServiceProxy
 
-from combadge.core.interfaces import ProvidesBinder
 from combadge.support.soap.response import BaseSoapFault
 
 _ServiceProxyT = TypeVar("_ServiceProxyT", bound=ServiceProxy)
@@ -41,11 +41,14 @@ _SoapFaultT = TypeVar("_SoapFaultT")
 _UNSET = object()
 
 
-class BaseZeepBackend(ABC, ProvidesBinder, Generic[_ServiceProxyT, _OperationProxyT]):
+class BaseZeepBackend(BaseBackend, ABC, Generic[_ServiceProxyT, _OperationProxyT]):
     """Base class for the sync and async backends. Not intended for a direct use."""
+
+    __slots__ = ("_service_cache", "_service")
 
     def __init__(self, service: _ServiceProxyT) -> None:
         """Instantiate the backend."""
+        super().__init__()
         self._service = service
 
     @staticmethod

--- a/combadge/support/zeep/backends/sync.py
+++ b/combadge/support/zeep/backends/sync.py
@@ -5,14 +5,13 @@ from os import PathLike, fspath
 from types import TracebackType
 from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 from zeep import Client, Plugin, Transport
 from zeep.exceptions import Fault
 from zeep.helpers import serialize_object
 from zeep.proxy import OperationProxy, ServiceProxy
 from zeep.wsse import UsernameToken
 
-from combadge.core.backend import ServiceContainer
 from combadge.core.binder import BaseBoundService
 from combadge.core.errors import BackendError
 from combadge.core.interfaces import ServiceMethod
@@ -21,7 +20,7 @@ from combadge.support.soap.request import Request
 from combadge.support.zeep.backends.base import BaseZeepBackend, ByBindingName, ByServiceName
 
 
-class ZeepBackend(BaseZeepBackend[ServiceProxy, OperationProxy], ServiceContainer):
+class ZeepBackend(BaseZeepBackend[ServiceProxy, OperationProxy]):
     """Synchronous Zeep service."""
 
     __slots__ = ("_service", "_service_cache")
@@ -77,10 +76,11 @@ class ZeepBackend(BaseZeepBackend[ServiceProxy, OperationProxy], ServiceContaine
             service: [service proxy object](https://docs.python-zeep.org/en/master/client.html#the-serviceproxy-object)
         """
         BaseZeepBackend.__init__(self, service)
-        ServiceContainer.__init__(self)
 
-    def bind_method(self, signature: Signature) -> ServiceMethod[ZeepBackend]:  # noqa: D102
-        response_type, fault_type = self._adapt_response_type(signature.return_type)
+    @classmethod
+    @override
+    def bind_method(cls, signature: Signature, /) -> ServiceMethod[ZeepBackend]:  # noqa: D102
+        response_type, fault_type = cls._adapt_response_type(signature.return_type)
 
         def bound_method(self: BaseBoundService[ZeepBackend], *args: Any, **kwargs: Any) -> Any:
             request = signature.build_request(Request, self, args, kwargs)

--- a/docs/cookbook/capturing-http-status-code.md
+++ b/docs/cookbook/capturing-http-status-code.md
@@ -16,12 +16,12 @@ if sys.version_info < (3, 9):
     pytest.skip("HTTP 418 requires Python 3.9 or higher")
 
 from http import HTTPStatus
+from typing import Protocol
 
 from httpx import Client
 from pydantic import BaseModel
 from typing_extensions import Annotated
 
-from combadge.core.interfaces import SupportsService
 from combadge.core.markers import Mixin
 from combadge.support.http.markers import StatusCode, http_method, path
 from combadge.support.httpx.backends.sync import HttpxBackend
@@ -31,7 +31,7 @@ class Response(BaseModel):
     my_status_code: HTTPStatus
 
 
-class SupportsHttpbin(SupportsService):
+class SupportsHttpbin(Protocol):
     @http_method("GET")
     @path("/status/418")
     def get_teapot(self) -> Annotated[Response, Mixin(StatusCode("my_status_code"))]:
@@ -39,7 +39,7 @@ class SupportsHttpbin(SupportsService):
 
 
 backend = HttpxBackend(Client(base_url="https://httpbin.org"), raise_for_status=False)
-service = SupportsHttpbin.bind(backend)
+service = backend[SupportsHttpbin]
 
 response = service.get_teapot()
 assert response.my_status_code == HTTPStatus.IM_A_TEAPOT

--- a/docs/core/service-container.md
+++ b/docs/core/service-container.md
@@ -3,6 +3,6 @@
 The built-in backend classes also implement the _service container_ in order to
 simplify the binding process:
 
-::: combadge.core.backend.ServiceContainer
+::: combadge.core.backend.BaseBackend
     options:
       heading_level: 2

--- a/docs/core/service-protocol.md
+++ b/docs/core/service-protocol.md
@@ -3,7 +3,3 @@
 In Combadge a definition of a service _protocol_ (also known as _interface_) is de-coupled from a service _implementation_. That allows a developer to define a service's interface and later bind it to a [_backend_][backends] which in turn is directly responsible for handling requests and responses.
 
 To define a service protocol one makes use of the [PEP 544](https://peps.python.org/pep-0544/) aka «structural subtyping». Combadge inspects the protocol during «binding».
-
-::: combadge.core.interfaces.SupportsService
-    options:
-      show_root_heading: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,6 @@ declared by a [protocol](https://peps.python.org/pep-0544/) class or an abstract
     from pytest import raises
     from typing_extensions import Annotated
 
-    from combadge.core.interfaces import SupportsService
     from combadge.core.response import ErrorResponse, SuccessfulResponse
     from combadge.support.http.markers import Payload
     from combadge.support.soap.markers import operation_name
@@ -98,7 +97,7 @@ declared by a [protocol](https://peps.python.org/pep-0544/) class or an abstract
 
 
     # 4️⃣ Declare the interface:
-    class SupportsNumberConversion(SupportsService, Protocol):
+    class SupportsNumberConversion(Protocol):
         @operation_name("NumberToWords")
         def number_to_words(
             self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 allow_redefinition = true
 allow_untyped_globals = true
 check_untyped_defs = true
+disable_error_code = "type-abstract" # https://github.com/python/mypy/issues/4717
 pretty = true
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/tests/core/test_binder.py
+++ b/tests/core/test_binder.py
@@ -2,10 +2,7 @@ from abc import abstractmethod
 from typing import Any, Callable, Protocol
 from unittest.mock import Mock
 
-from typing_extensions import assert_type
-
 from combadge.core.binder import _enumerate_methods, _wrap, bind
-from combadge.core.interfaces import SupportsService
 from combadge.core.markers.method import MethodMarker, wrap_with
 from combadge.core.service import BaseBoundService
 
@@ -13,7 +10,7 @@ from combadge.core.service import BaseBoundService
 def test_enumerate_bindable_methods() -> None:
     """Test that bindable methods are returned."""
 
-    class TestService(SupportsService, Protocol):
+    class TestService(Protocol):
         @abstractmethod
         def invoke(self) -> None:
             raise NotImplementedError
@@ -31,7 +28,7 @@ def test_enumerate_bindable_methods() -> None:
 def test_enumerate_class_methods() -> None:
     """Test that class methods are ignored."""
 
-    class TestService(SupportsService, Protocol):
+    class TestService(Protocol):
         @classmethod
         def ignored(cls) -> None:
             raise NotImplementedError
@@ -42,7 +39,7 @@ def test_enumerate_class_methods() -> None:
 def test_enumerate_private_methods() -> None:
     """Test that «private» methods are ignored."""
 
-    class TestService(SupportsService, Protocol):
+    class TestService(Protocol):
         def _ignored(self) -> None:
             raise NotImplementedError
 
@@ -74,13 +71,6 @@ def test_decorator_ordering() -> None:
 def test_protocol_class_var() -> None:
     class ServiceProtocol(Protocol): ...
 
-    service = bind(ServiceProtocol, Mock())  # type: ignore[type-abstract]
+    service = bind(ServiceProtocol, Mock())
     assert isinstance(service, BaseBoundService)
     assert service.__combadge_protocol__ is ServiceProtocol
-
-
-def test_service_type() -> None:
-    class ServiceProtocol(SupportsService): ...
-
-    service = ServiceProtocol.bind(Mock())
-    assert_type(service, ServiceProtocol)

--- a/tests/integration/test_country_info_service.py
+++ b/tests/integration/test_country_info_service.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field
 from zeep import Client
 
 from combadge.core.errors import BackendError
-from combadge.core.interfaces import SupportsService
 from combadge.support.soap.markers import operation_name
 from combadge.support.zeep.backends.sync import ZeepBackend
 
@@ -18,7 +17,7 @@ class Continent(BaseModel):
     name: Annotated[str, Field(alias="sName")]
 
 
-class SupportsCountryInfo(SupportsService, Protocol):
+class SupportsCountryInfo(Protocol):
     @operation_name("ListOfContinentsByName")
     @abstractmethod
     def list_of_continents_by_name(self) -> list[Continent]:
@@ -32,7 +31,7 @@ class SupportsCountryInfo(SupportsService, Protocol):
 @pytest.fixture
 def country_info_service() -> Iterable[SupportsCountryInfo]:
     with Client(wsdl=str(Path(__file__).parent / "wsdl" / "CountryInfoService.wsdl")) as client:
-        yield SupportsCountryInfo.bind(ZeepBackend(client.service))
+        yield ZeepBackend(client.service)[SupportsCountryInfo]
 
 
 @pytest.mark.vcr(decode_compressed_response=True)

--- a/tests/integration/test_number_conversion.py
+++ b/tests/integration/test_number_conversion.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field, HttpUrl, RootModel
 from typing_extensions import assert_type
 from zeep import AsyncClient, Client
 
-from combadge.core.interfaces import SupportsService
 from combadge.core.response import ErrorResponse, SuccessfulResponse
 from combadge.support.http.markers import Payload
 from combadge.support.soap.markers import operation_name
@@ -35,7 +34,7 @@ class _TestFault(BaseSoapFault):  # type: ignore[override]
     message: Literal["Test Fault"]
 
 
-class SupportsNumberConversion(SupportsService, Protocol):
+class SupportsNumberConversion(Protocol):
     @operation_name("NumberToWords")
     @abstractmethod
     def number_to_words(
@@ -45,7 +44,7 @@ class SupportsNumberConversion(SupportsService, Protocol):
         raise NotImplementedError
 
 
-class SupportsNumberConversionAsync(SupportsService, Protocol):
+class SupportsNumberConversionAsync(Protocol):
     @operation_name("NumberToWords")
     @abstractmethod
     async def number_to_words(
@@ -61,7 +60,7 @@ def number_conversion_service() -> Iterable[SupportsNumberConversion]:
         wsdl=str(Path(__file__).parent / "wsdl" / "NumberConversion.wsdl"),
         port_name="NumberConversionSoap",
     ) as client:
-        yield SupportsNumberConversion.bind(SyncZeepBackend(client.service))
+        yield SyncZeepBackend(client.service)[SupportsNumberConversion]
 
 
 @pytest.fixture
@@ -70,7 +69,7 @@ def number_conversion_service_async() -> Iterable[SupportsNumberConversionAsync]
         wsdl=str(Path(__file__).parent / "wsdl" / "NumberConversion.wsdl"),
         port_name="NumberConversionSoap",
     ) as client:
-        yield SupportsNumberConversionAsync.bind(AsyncZeepBackend(client.service))
+        yield AsyncZeepBackend(client.service)[SupportsNumberConversionAsync]
 
 
 @pytest.mark.vcr(decode_compressed_response=True)
@@ -126,7 +125,7 @@ def test_happy_path_with_params_sync(service: Union[ByServiceName, ByBindingName
         service=service,
         operation_timeout=1,
     )
-    service = SupportsNumberConversion.bind(backend)
+    service = backend[SupportsNumberConversion]
     response = service.number_to_words(NumberToWordsRequest(number=42)).unwrap()
     assert response.root == "forty two "
 
@@ -150,6 +149,6 @@ async def test_happy_path_with_params_async(service: Union[ByServiceName, ByBind
         service=service,
         operation_timeout=1,
     )
-    service = SupportsNumberConversionAsync.bind(backend)
+    service = backend[SupportsNumberConversionAsync]
     response = (await service.number_to_words(NumberToWordsRequest(number=42))).unwrap()
     assert response.root == "forty two "


### PR DESCRIPTION
- Remove `SupportsService`: inherit normally from `Protocol` and bind it from a backend
- Remove context manager protocol from bound service: backend may be used my multiple services, so use context manager protocol with the backend instead
- Remove `ProvidesBinder`
- Remove `MethodBinder`: it is merged into `BaseBackend`
- Merge `ServiceContainer` into the new `BaseBackend`
- Refactor `bind_class` to accept a backend directly